### PR TITLE
ci(permissions): add explicit permissions to build_containers workflow

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -11,9 +11,13 @@ env:
   REGISTRY_USER: ${{ github.actor }}
   REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
+permissions: read-all
+
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3


### PR DESCRIPTION
Set global permissions to read-all and grant packages write permission to the docker job to follow the principle of least privilege for GITHUB_TOKEN.

This restricts the default token permissions to read-only access globally, with the docker job explicitly granted write access only for packages (needed to push containers to ghcr.io). This improves the security posture of the workflow by limiting the scope of what the GITHUB_TOKEN can do.