### PR TITLE
fix(docs): correct broken link in v1.26 connection pooling

### DIFF
--- a/website/versioned_docs/version-1.26/connection_pooling.md
+++ b/website/versioned_docs/version-1.26/connection_pooling.md
@@ -441,7 +441,7 @@ Go runtime (with the prefix `go_*`).
 
 :::info
     You can inspect the exported metrics on a pod running PgBouncer. For instructions, see
-    [How to inspect the exported metrics](monitoring.md/#how-to-inspect-the-exported-metrics).
+    [How to inspect the exported metrics](monitoring#how-to-inspect-the-exported-metrics).
     Make sure that you use the correct IP and the `9127` port.
 :::
 


### PR DESCRIPTION
The link to monitoring section incorrectly used .md extension, causing the build to fail with a broken link error. Updated to use the correct Docusaurus link format without the extension.

Fixes the build failure in https://github.com/cloudnative-pg/docs/actions/runs/21164815569