### PR TITLE
fix(config): migrate onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -30,7 +30,6 @@ const config: Config = {
   deploymentBranch: 'gh-pages',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -178,6 +177,9 @@ const config: Config = {
           mdx1Compat: {
             allowComments: true,
             allowHtml: true,
+      },
+      hooks: {
+        onBrokenMarkdownLinks: 'throw',
       },
     },
     prism: {


### PR DESCRIPTION
This PR migrates the onBrokenMarkdownLinks configuration from the top-level config to markdown.hooks.onBrokenMarkdownLinks to fix the deprecation warning and ensure compatibility with Docusaurus v4.

The deprecated top-level configuration was causing the following warning during the build process:

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```

This change follows the recommended migration path by moving the setting to the new location under markdown.hooks while maintaining the same behavior (throwing on broken markdown links).