### PR TITLE
fix(redirects): add /current path support for latest version

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -197,6 +197,13 @@ const config: Config = {
                       from: '/',
                   },
               ],
+              createRedirects(existingPath) {
+                  // Redirect /current/* to the latest version
+                  if (existingPath.startsWith(`/${lastVersion}/`)) {
+                      return existingPath.replace(`/${lastVersion}/`, '/current/');
+                  }
+                  return undefined;
+              },
           },
       ],
   ],


### PR DESCRIPTION
The `/current` and `/current/*` paths were not accessible, causing 404 errors for external references. This implements native Docusaurus redirects using the createRedirects function to automatically map all `/current/*` paths to the corresponding paths in the latest version.

Closes #24 