### PR TITLE
docs(readme): add production build testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ yarn build
 This command generates static content into the `build` directory and can be
 served using any static contents hosting service.
 
+## Testing Production Features
+
+Some features, like redirects, only work in production builds and are not
+available during local development (`yarn start`). To test these features
+locally:
+
+```bash
+yarn build
+yarn serve
+```
+
+This builds the site and serves it locally, allowing you to test production-only
+features.
+
 ## Deployment
 
 Using SSH:


### PR DESCRIPTION
Explains how to test production-only features like redirects using yarn build and yarn serve, addressing confusion from PR #38 where redirects only work in production builds.