### PR TITLE
fix(docs): set correct command for logs

### DIFF
--- a/website/docs/kubectl-plugin.md
+++ b/website/docs/kubectl-plugin.md
@@ -840,14 +840,14 @@ kubectl cnpg logs cluster CLUSTER [flags]
 Using the `-f` option to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f
+kubectl cnpg logs cluster CLUSTER -f
 ```
 
 Using `--tail` option to display 3 lines from each pod and the `-f` option
 to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f --tail 3
+kubectl cnpg logs cluster CLUSTER -f --tail 3
 ```
 
 ```output

--- a/website/versioned_docs/version-1.25/kubectl-plugin.md
+++ b/website/versioned_docs/version-1.25/kubectl-plugin.md
@@ -792,14 +792,14 @@ kubectl cnpg logs cluster CLUSTER [flags]
 Using the `-f` option to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f
+kubectl cnpg logs cluster CLUSTER -f
 ```
 
 Using `--tail` option to display 3 lines from each pod and the `-f` option
 to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f --tail 3
+kubectl cnpg logs cluster CLUSTER -f --tail 3
 ```
 
 ```output

--- a/website/versioned_docs/version-1.26/kubectl-plugin.md
+++ b/website/versioned_docs/version-1.26/kubectl-plugin.md
@@ -840,14 +840,14 @@ kubectl cnpg logs cluster CLUSTER [flags]
 Using the `-f` option to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f
+kubectl cnpg logs cluster CLUSTER -f
 ```
 
 Using `--tail` option to display 3 lines from each pod and the `-f` option
 to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f --tail 3
+kubectl cnpg logs cluster CLUSTER -f --tail 3
 ```
 
 ```output

--- a/website/versioned_docs/version-1.27/kubectl-plugin.md
+++ b/website/versioned_docs/version-1.27/kubectl-plugin.md
@@ -800,14 +800,14 @@ kubectl cnpg logs cluster CLUSTER [flags]
 Using the `-f` option to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f
+kubectl cnpg logs cluster CLUSTER -f
 ```
 
 Using `--tail` option to display 3 lines from each pod and the `-f` option
 to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f --tail 3
+kubectl cnpg logs cluster CLUSTER -f --tail 3
 ```
 
 ```output

--- a/website/versioned_docs/version-1.28/kubectl-plugin.md
+++ b/website/versioned_docs/version-1.28/kubectl-plugin.md
@@ -840,14 +840,14 @@ kubectl cnpg logs cluster CLUSTER [flags]
 Using the `-f` option to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f
+kubectl cnpg logs cluster CLUSTER -f
 ```
 
 Using `--tail` option to display 3 lines from each pod and the `-f` option
 to follow:
 
 ```sh
-kubectl cnpg report cluster CLUSTER -f --tail 3
+kubectl cnpg logs cluster CLUSTER -f --tail 3
 ```
 
 ```output


### PR DESCRIPTION
command was cnpg report in lieu of cnpg logs : backported to all versions for consistency