### PR TITLE
fix(security): harden GitHub Actions workflows against expression injection

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -26,8 +26,8 @@ jobs:
           token: '${{ secrets.REPO_PAT }}'
       - name: Import docs
         run: |
-          echo "Importing CloudNativePG docs for version: ${{ env.VERSION }}"
-          ./scripts/import_docs.sh "${{ env.VERSION }}"
+          echo "Importing CloudNativePG docs for version: ${VERSION}"
+          ./scripts/import_docs.sh "${VERSION}"
       - name: Commit and push changes
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:


### PR DESCRIPTION
Move `${{ }}` expressions from `run:` blocks into step-level `env:` blocks, then reference them as properly-quoted shell variables.

Part of cloudnative-pg/cloudnative-pg#10113

Assisted-by: Claude Opus 4.6