### PR TITLE
fix(sidebar): hide release_notes directory and backup_recovery from autogenerated sidebar

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -50,6 +50,16 @@ const config: Config = {
           includeCurrentVersion: true, // Include the current version in the sidebar
           lastVersion: lastVersion,
           versions: versionsConfig,
+          async sidebarItemsGenerator({defaultSidebarItemsGenerator, ...args}) {
+            const items = await defaultSidebarItemsGenerator(args);
+            return items.filter((item) => {
+              // Remove the release_notes directory category from the sidebar
+              if (item.type === 'category' && item.label === 'release_notes') return false;
+              // Remove the legacy backup_recovery stub page from the sidebar
+              if (item.type === 'doc' && item.id === 'backup_recovery') return false;
+              return true;
+            });
+          },
         },
         blog: false,
         theme: {


### PR DESCRIPTION
With autogenerated sidebars, Docusaurus creates a separate category entry for the release_notes/ directory in addition to the release_notes.md page, resulting in a duplicate and broken "release_notes" entry in the navigation menu.

The legacy backup_recovery stub page also appears in the sidebar but should not, as its content has been split into separate backup and recovery pages.

Add a custom sidebarItemsGenerator that filters out both entries while keeping the pages accessible via direct links.