### PR TITLE
[Doc] Added note about verbose mode requirement

### DIFF
--- a/website/docs/tablespaces.md
+++ b/website/docs/tablespaces.md
@@ -366,6 +366,8 @@ Instances status
 [...]
 ```
 
+Please note that above output is available in verbose mode only (`kubectl cnpg status -v`).
+
 ## Limitations
 
 Currently, you can't remove tablespaces from an existing CloudNativePG


### PR DESCRIPTION
The `status` command outputs information about cluster's tablespaces in verbose mode only

This is PR for Issue [#10380](https://github.com/cloudnative-pg/cloudnative-pg/issues/10380)