### PR TITLE
ci(cd): scope CD concurrency group per ref

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -11,10 +11,12 @@ on:
     paths:
       - 'website/**'
 
-# Prevent parallel deployments when multiple commits are pushed to main
-# in a short time.
+# Concurrency only matters on main, to avoid parallel Pages
+# deployments when several commits land in a short time. The ref is
+# included in the group name so PR runs each get their own queue
+# and don't cancel each other.
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: false
 
 permissions: read-all


### PR DESCRIPTION
The shared "pages" group cancels pending PR runs whenever another PR queues behind it, letting broken PRs merge without a build. Include github.ref so each ref has its own queue.

Closes #78