### PR TITLE
docs: warning about running multiple namespaced deployments

### DIFF
--- a/website/docs/operator_conf.md
+++ b/website/docs/operator_conf.md
@@ -222,3 +222,14 @@ You can also access pprof using the browser at [http://localhost:6060/debug/ppro
     Treat pprof as a sensitive debugging interface and never expose it publicly.
     If you must access it remotely, secure it with proper network policies and access controls.
 :::
+
+## Multiple Namespaced Deployments
+
+:::warning
+    CloudNativePG does NOT currently support running multiple operators on
+    the same cluster. While this can be achieved through the use of namespaced
+    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
+    multiple operators still use the same set of shared CRDs. We cannot
+    guarantee a backwards compatible upgrade across multiple concurrently
+    running operators.
+:::

--- a/website/versioned_docs/version-1.30/operator_conf.md
+++ b/website/versioned_docs/version-1.30/operator_conf.md
@@ -222,3 +222,14 @@ You can also access pprof using the browser at [http://localhost:6060/debug/ppro
     Treat pprof as a sensitive debugging interface and never expose it publicly.
     If you must access it remotely, secure it with proper network policies and access controls.
 :::
+
+## Multiple Namespaced Deployments
+
+:::warning
+    CloudNativePG does NOT currently support running multiple operators on
+    the same cluster. While this can be achieved through the use of namespaced
+    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
+    multiple operators still use the same set of shared CRDs. We cannot
+    guarantee a backwards compatible upgrade across multiple concurrently
+    running operators.
+:::


### PR DESCRIPTION

> [!WARNING]
> CloudNativePG does NOT currently support running multiple operators on
> the same cluster. While this can be achieved through the use of namespaced
> deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
> multiple operators still use the same set of shared CRDs. We cannot
> guarantee a backwards compatible upgrade across multiple concurrently
> running operators.